### PR TITLE
use debian:jessie-backports, and jdk-8 instead of jdk-7

### DIFF
--- a/acid/Dockerfile.template
+++ b/acid/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM debian:testing
+FROM debian:jessie-backports
 MAINTAINER linostar
 LABEL Description="Configure and run acid bots" \
       Warning="This container depends on external provision files and cannot be built on its own"
@@ -6,7 +6,7 @@ RUN sed -i "s/httpredir.debian.org/ftp.us.debian.org/g" /etc/apt/sources.list
 RUN apt-get update; apt-get upgrade -y
 RUN apt-get install -y -f sudo wget gcc g++ make git mysql-client libmysqld-dev nano mlocate
 RUN apt-get install -y python python-dev libpython-dev python-pip
-RUN apt-get install -y openjdk-7-jdk maven
+RUN apt-get install -y openjdk-8-jdk maven
 RUN update-ca-certificates -f
 RUN adduser --system --home /var/ircd --shell /bin/bash ircd
 RUN rm /bin/sh; ln -s /bin/bash /bin/sh


### PR DESCRIPTION
jdk-7 is no longer distributed, instead jdk-8 is now.

I haven't been able to get it working proper yet for other reasons so I have not actually tested this to make sure acid launches and works properly, but while I was building it spit out something saying it can't find the `openjdk-7-jdk` package, so I quickly swapped this over and it stopped giving me that error while building.
